### PR TITLE
Fix input_selector initialization to use from_yaml

### DIFF
--- a/custom_components/climate_scheduler/switch.py
+++ b/custom_components/climate_scheduler/switch.py
@@ -386,7 +386,7 @@ class ClimateSchedulerSwitch(SwitchEntity, RestoreEntity):
             CONF_INITIAL: self.current_profile_id,
         }
 
-        self._profile_selector = InputSelect(selector_config)
+        self._profile_selector = InputSelect.from_yaml(selector_config)
         await input_select_platform.async_add_entities([self._profile_selector])
 
         # Subscribe for profile changes


### PR DESCRIPTION
Fix for issue https://github.com/FrancisLab/hass-climate-scheduler/issues/7. 

Thanks to @pascalrheaume! 

> Following update to homeassistant core to InputSelect class (https://github.com/home-assistant/core/commit/b0d033ef29abaf5ef8265d596cdaa3da8c124695)
> 
> self._profile_selector = InputSelect(selector_config) in [switch.py](https://github.com/FrancisLab/hass-climate-scheduler/blob/22d1ab05f372e620f4a0b028b2ecd22a0475de28/custom_components/climate_scheduler/switch.py#L389) line 389 gives this error:
> File "/usr/src/homeassistant/homeassistant/components/input_select/init.py", line 296, in extra_state_attributes
> return {ATTR_EDITABLE: self.editable}
> AttributeError: 'InputSelect' object has no attribute 'editable'
> 
> Fixed it by calling
> self._profile_selector = InputSelect.from_yaml(selector_config)