### PR TITLE
Switch to tasks+asyncio.gather for Python 3.11 compat

### DIFF
--- a/custom_components/climate_scheduler/switch.py
+++ b/custom_components/climate_scheduler/switch.py
@@ -498,10 +498,10 @@ class ClimateSchedulerSwitch(SwitchEntity, RestoreEntity):
         climate_data = self._current_profile.compute_climate(time_of_day)
 
         update_tasks = [
-            self._async_update_climate_entity(entity, climate_data)
+            asyncio.create_task(self._async_update_climate_entity(entity, climate_data))
             for entity in self._climate_entities
         ]
-        await asyncio.wait(update_tasks)
+        await asyncio.gather(*update_tasks)
 
     async def _async_update_climate_entity(
         self, entity: str, data: Optional[ComputedClimateData]


### PR DESCRIPTION
Latest versions of Home Assistant started using Python 3.11 which introduced a breaking change to 'asyncio.wait' where passing in coroutines is now forbidden. This addresses the issue by creating tasks & awaiting them all with 'asyncio.gather' instead.